### PR TITLE
Remove pysssss CheckpointLoader references

### DIFF
--- a/py/better_combos.py
+++ b/py/better_combos.py
@@ -163,10 +163,8 @@ class CheckpointLoaderSimpleWithImages(CheckpointLoaderSimple):
 
 NODE_CLASS_MAPPINGS = {
     "LoraLoader|pysssss": LoraLoaderWithImages,
-    "CheckpointLoader|pysssss": CheckpointLoaderSimpleWithImages,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "LoraLoader|pysssss": "Lora Loader 🐍",
-    "CheckpointLoader|pysssss": "Checkpoint Loader 🐍",
 }

--- a/web/js/modelInfo.js
+++ b/web/js/modelInfo.js
@@ -382,7 +382,7 @@ app.registerExtension({
 		);
 		addSetting(
 			"Checkpoint",
-			["CheckpointLoader.ckpt_name", "CheckpointLoaderSimple", "CheckpointLoader|pysssss", "Efficient Loader", "Eff. Loader SDXL"].join(",")
+                        ["CheckpointLoader.ckpt_name", "CheckpointLoaderSimple", "Efficient Loader", "Eff. Loader SDXL"].join(",")
 		);
 
 		app.ui.settings.addSetting({

--- a/web/js/quickNodes.js
+++ b/web/js/quickNodes.js
@@ -143,11 +143,10 @@ app.registerExtension({
 		}
 
 		if (
-			nodeData.name === "CheckpointLoaderSimple" ||
-			nodeData.name === "CheckpointLoader" ||
-			nodeData.name === "CheckpointLoader|pysssss" ||
-			nodeData.name === "LoraLoader" ||
-			nodeData.name === "LoraLoader|pysssss"
+                        nodeData.name === "CheckpointLoaderSimple" ||
+                        nodeData.name === "CheckpointLoader" ||
+                        nodeData.name === "LoraLoader" ||
+                        nodeData.name === "LoraLoader|pysssss"
 		) {
 			addMenuHandler(nodeType, function (_, options) {
 				function addLora(type) {


### PR DESCRIPTION
## Summary
- drop support for `CheckpointLoader|pysssss` in quick nodes, combo menus, and model info
- trim betterCombos to only handle LoRA loader
- remove Python mappings for the pysssss checkpoint loader

## Testing
- `node --check web/js/quickNodes.js`
- `node --check web/js/betterCombos.js`
- `node --check web/js/modelInfo.js`
- `python -m py_compile py/better_combos.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22ed878348331854706af86c4edde